### PR TITLE
user can like and dislike products

### DIFF
--- a/Bangazon/Controllers/ProductsController.cs
+++ b/Bangazon/Controllers/ProductsController.cs
@@ -255,6 +255,34 @@ namespace Bangazon.Controllers
             return RedirectToAction(nameof(Index));
         }
 
+        //POST: Products/UserLikePreference
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<ActionResult> UserLikePreference(int ProductId, bool liked)
+        {
+            var user = await GetUserAsync();
+            var currentPreference = await _context.UserProducts.FirstOrDefaultAsync(p => p.ProductId == ProductId && p.UserId == user.Id);
+            if (currentPreference == null)
+            {
+                var userProduct = new UserProduct()
+                {
+                    UserId = user.Id,
+                    ProductId = ProductId,
+                    IsLiked = liked
+                };
+                _context.UserProducts.Add(userProduct);
+
+            }else
+            {
+                currentPreference.IsLiked = liked;
+                _context.UserProducts.Update(currentPreference);
+            }
+       
+            await _context.SaveChangesAsync();
+
+            return RedirectToAction("Details", new { id = ProductId });
+        }
+
 
 
         // GET: Products/Delete/5

--- a/Bangazon/Data/ApplicationDbContext.cs
+++ b/Bangazon/Data/ApplicationDbContext.cs
@@ -16,6 +16,7 @@ namespace Bangazon.Data {
         public DbSet<PaymentType> PaymentType { get; set; }
         public DbSet<Order> Order { get; set; }
         public DbSet<OrderProduct> OrderProduct { get; set; }
+        public DbSet<UserProduct> UserProducts { get; set; }
 
         protected override void OnModelCreating (ModelBuilder modelBuilder) {
             base.OnModelCreating (modelBuilder);

--- a/Bangazon/Migrations/20200428150803_UserProducts.Designer.cs
+++ b/Bangazon/Migrations/20200428150803_UserProducts.Designer.cs
@@ -4,14 +4,16 @@ using Bangazon.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Bangazon.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200428150803_UserProducts")]
+    partial class UserProducts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Bangazon/Migrations/20200428150803_UserProducts.cs
+++ b/Bangazon/Migrations/20200428150803_UserProducts.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Bangazon.Migrations
+{
+    public partial class UserProducts : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ProfileViewModel",
+                columns: table => new
+                {
+                    Id = table.Column<string>(nullable: false),
+                    FirstName = table.Column<string>(nullable: false),
+                    LastName = table.Column<string>(nullable: false),
+                    StreetAddress = table.Column<string>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProfileViewModel", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserProducts",
+                columns: table => new
+                {
+                    UserProductId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<string>(nullable: true),
+                    ProductId = table.Column<int>(nullable: false),
+                    IsLiked = table.Column<bool>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserProducts", x => x.UserProductId);
+                });
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "00000000-ffff-ffff-ffff-ffffffffffff",
+                columns: new[] { "ConcurrencyStamp", "PasswordHash" },
+                values: new object[] { "e429399a-1e6d-431e-a247-d7cf6573ce5c", "AQAAAAEAACcQAAAAELlPx7sihn5zS8xLTpgk0viY71Er5VnllRU1pMtHnLZXdIaFmylAvJsWb34uN3a0nA==" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProfileViewModel");
+
+            migrationBuilder.DropTable(
+                name: "UserProducts");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "00000000-ffff-ffff-ffff-ffffffffffff",
+                columns: new[] { "ConcurrencyStamp", "PasswordHash" },
+                values: new object[] { "b3176fce-82ee-4984-9e47-e8cc21ef9771", "AQAAAAEAACcQAAAAEONB2zzIbCTKHbBGsZCLZC6IpPhOGtLtV9n6ipvBvnVVoxHAHBV2ppZtgGo+GeIakQ==" });
+        }
+    }
+}

--- a/Bangazon/Models/Product.cs
+++ b/Bangazon/Models/Product.cs
@@ -60,6 +60,7 @@ namespace Bangazon.Models
         {
             Active = true;
         }
+  
 
     }
 }

--- a/Bangazon/Models/ProductViewModels/ProductFormViewModel.cs
+++ b/Bangazon/Models/ProductViewModels/ProductFormViewModel.cs
@@ -9,5 +9,6 @@ namespace Bangazon.Models.ProductViewModels
     public class ProductFormViewModel : Product
     {
         public List<SelectListItem> ProductTypeOptions { get; set; }
+        public bool IsLiked { get; set; }
     }
 }

--- a/Bangazon/Models/UserProduct.cs
+++ b/Bangazon/Models/UserProduct.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Bangazon.Models
+{
+    public class UserProduct
+    {
+        public int UserProductId { get; set; }
+        public string UserId { get; set; }
+        public int ProductId { get; set; }
+        public bool IsLiked { get; set; }
+    }
+}

--- a/Bangazon/Views/Products/Details.cshtml
+++ b/Bangazon/Views/Products/Details.cshtml
@@ -9,7 +9,18 @@
 <div>
     <h4>Product</h4>
     <hr />
-
+    @using (Html.BeginForm("UserLikePreference", "Products"))
+    {
+        <input asp-for="IsLiked" type="hidden" name="liked" value="True" class="form-control" />
+        <input asp-for="ProductId" type="hidden" value="@Model.ProductId" class="form-control" />
+        <input type="submit" value="Like" class="btn btn-primary" />
+        }
+    @using (Html.BeginForm("UserLikePreference", "Products"))
+    {
+        <input asp-for="IsLiked" type="hidden" name="liked" value="False"  class="form-control" />
+        <input asp-for="ProductId" type="hidden" value="@Model.ProductId" class="form-control" />
+        <input type="submit" value="Dislike" class="btn btn-primary" />
+}
     <dl class="row">
 
         <dt class="col-sm-2">
@@ -69,10 +80,11 @@
             @Html.DisplayFor(model => model.ProductType.Label)
         </dd>
     </dl>
-   @using (Html.BeginForm("AddToOrder", "Products")) {
+    @using (Html.BeginForm("AddToOrder", "Products"))
+    {
         <input asp-for="ProductId" type="hidden" value="@Model.ProductId" class="form-control" />
         <input type="submit" value="Add to Order" class="btn btn-primary" />
-   }
+    }
 </div>
 <div>
     <a class="btn btn-link" asp-action="Index">Back to List</a>


### PR DESCRIPTION
# Description

Given the user is authenticated
When the user is viewing a product detail page
Then a like and dislike button should be presented next to the product title

Given the user is authenticated
When the user clicks on the like or dislike icon
Then that preference should be stored for the current user

Fixes #22 

## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)


# Testing Instructions

Update database with migration.  Go to details page and like/dislike a product

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
