### PR TITLE
added Expiration migration, expiration to payment options, and valida…

### DIFF
--- a/Bangazon/Controllers/PaymentTypesController.cs
+++ b/Bangazon/Controllers/PaymentTypesController.cs
@@ -53,7 +53,7 @@ namespace Bangazon.Controllers
 
             try
             {
-                if (ModelState.IsValid)
+                if (paymentTypeModel.Expiration > DateTime.Now)
                 {
                     var user = await GetUserAsync();
                     var paymentType = new PaymentType()

--- a/Bangazon/Controllers/PaymentTypesController.cs
+++ b/Bangazon/Controllers/PaymentTypesController.cs
@@ -7,6 +7,7 @@ using Bangazon.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Server.IIS;
 using Microsoft.EntityFrameworkCore;
 
 namespace Bangazon.Controllers
@@ -49,19 +50,25 @@ namespace Bangazon.Controllers
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> Create(PaymentType paymentTypeModel)
         {
+
             try
             {
-                var user = await GetUserAsync();
-                var paymentType = new PaymentType()
+                if (ModelState.IsValid)
                 {
-                    UserId = user.Id,
-                    Description = paymentTypeModel.Description,
-                    AccountNumber = paymentTypeModel.AccountNumber
-                };
-                _context.PaymentType.Add(paymentType);
-                await _context.SaveChangesAsync();
+                    var user = await GetUserAsync();
+                    var paymentType = new PaymentType()
+                    {
+                        UserId = user.Id,
+                        Description = paymentTypeModel.Description,
+                        AccountNumber = paymentTypeModel.AccountNumber,
+                        Expiration = paymentTypeModel.Expiration
+                    };
+                    _context.PaymentType.Add(paymentType);
+                    await _context.SaveChangesAsync();
 
-                return RedirectToAction(nameof(Index));
+                    return RedirectToAction(nameof(Index));
+                }
+                return View();
             }
             catch (Exception ex)
             {

--- a/Bangazon/Migrations/20200428183641_PaymentTypeExpiration.Designer.cs
+++ b/Bangazon/Migrations/20200428183641_PaymentTypeExpiration.Designer.cs
@@ -4,14 +4,16 @@ using Bangazon.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Bangazon.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200428183641_PaymentTypeExpiration")]
+    partial class PaymentTypeExpiration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -215,6 +217,7 @@ namespace Bangazon.Migrations
                         .HasMaxLength(55);
 
                     b.Property<DateTime>("Expiration")
+                        .IsRequired()
                         .HasColumnType("datetime2");
 
                     b.Property<string>("UserId")

--- a/Bangazon/Migrations/20200428183641_PaymentTypeExpiration.cs
+++ b/Bangazon/Migrations/20200428183641_PaymentTypeExpiration.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Bangazon.Migrations
+{
+    public partial class PaymentTypeExpiration : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "Expiration",
+                table: "PaymentType",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "00000000-ffff-ffff-ffff-ffffffffffff",
+                columns: new[] { "ConcurrencyStamp", "PasswordHash" },
+                values: new object[] { "d3cb6c84-691a-46fd-8e22-60fc201a7f63", "AQAAAAEAACcQAAAAELaZTTtKPCn6VQgR2odGsh3nwIc5PaPfch/Ilcm/5pLDVC10mjYjtl/g2JhND2INVA==" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Expiration",
+                table: "PaymentType");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "00000000-ffff-ffff-ffff-ffffffffffff",
+                columns: new[] { "ConcurrencyStamp", "PasswordHash" },
+                values: new object[] { "e429399a-1e6d-431e-a247-d7cf6573ce5c", "AQAAAAEAACcQAAAAELlPx7sihn5zS8xLTpgk0viY71Er5VnllRU1pMtHnLZXdIaFmylAvJsWb34uN3a0nA==" });
+        }
+    }
+}

--- a/Bangazon/Models/PaymentType.cs
+++ b/Bangazon/Models/PaymentType.cs
@@ -6,7 +6,17 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Bangazon.Models
 {
-  public class PaymentType
+    public class MyDateAttribute : ValidationAttribute
+    {
+        public override bool IsValid(object value)
+        {
+            DateTime d = Convert.ToDateTime(value);
+            return d >= DateTime.Now; //Dates Greater than or equal to today are valid (true)
+        }
+    }
+
+
+    public class PaymentType
   {
     [Key]
     public int PaymentTypeId { get; set; }
@@ -23,6 +33,11 @@ namespace Bangazon.Models
     [Required]
     [StringLength(20)]
     public string AccountNumber { get; set; }
+
+    [Required]
+    [DataType(DataType.Date)]
+    [MyDate(ErrorMessage = "Invalid date")]
+    public DateTime Expiration { get; set; }
 
     [Required]
     public string UserId {get; set;}

--- a/Bangazon/Views/PaymentTypes/Create.cshtml
+++ b/Bangazon/Views/PaymentTypes/Create.cshtml
@@ -23,6 +23,11 @@
                 <span asp-validation-for="AccountNumber" class="text-danger"></span>
             </div>
             <div class="form-group">
+                <label asp-for="Expiration" class="control-label"></label>
+                <input type="date" asp-for="Expiration" class="form-control" />
+                <span asp-validation-for="Expiration" class="text-danger"></span>
+            </div>
+            <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-primary" />
             </div>
         </form>
@@ -30,7 +35,7 @@
 </div>
 
 <div>
-    <a asp-action="Index">View Payment Types</a>
+    <a class="btn btn-link" asp-action="Index">View Payment Types</a>
 </div>
 
 @section Scripts {


### PR DESCRIPTION
…tion for expired payment types

# Description

Given a user is entering a payment type
When the user clicks the affordance to save the payment type
And the expiration date is prior to the current date
Then the user should be notified that the expiration date is invalid
And the record should not be added

Fixes #25 

## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)

# Testing Instructions
Update database with new migration.
Attempt to create a new payment type with an expiration date in the future.  New payment type should be added to the database.
Attempt to add a new payment type with an expiration date before today.  After the create button is clicked, error should say invalid date and it should not be added to the database.  


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
