### PR TITLE
Aab local delivery

### DIFF
--- a/Bangazon/Migrations/20200429152702_LocalDelivery.Designer.cs
+++ b/Bangazon/Migrations/20200429152702_LocalDelivery.Designer.cs
@@ -4,14 +4,16 @@ using Bangazon.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace Bangazon.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200429152702_LocalDelivery")]
+    partial class LocalDelivery
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Bangazon/Migrations/20200429152702_LocalDelivery.cs
+++ b/Bangazon/Migrations/20200429152702_LocalDelivery.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Bangazon.Migrations
+{
+    public partial class LocalDelivery : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "LocalDelivery",
+                table: "Product",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "00000000-ffff-ffff-ffff-ffffffffffff",
+                columns: new[] { "ConcurrencyStamp", "PasswordHash" },
+                values: new object[] { "fc849e1a-d192-4314-a36e-65e8eedcbd04", "AQAAAAEAACcQAAAAEDNIN7CnortAh0mgb6A4iDBWz7e2CnelT12kNueNAPJuKbLyU6EjFHmBXovLbF1QNw==" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LocalDelivery",
+                table: "Product");
+
+            migrationBuilder.UpdateData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: "00000000-ffff-ffff-ffff-ffffffffffff",
+                columns: new[] { "ConcurrencyStamp", "PasswordHash" },
+                values: new object[] { "d3cb6c84-691a-46fd-8e22-60fc201a7f63", "AQAAAAEAACcQAAAAELaZTTtKPCn6VQgR2odGsh3nwIc5PaPfch/Ilcm/5pLDVC10mjYjtl/g2JhND2INVA==" });
+        }
+    }
+}

--- a/Bangazon/Models/Product.cs
+++ b/Bangazon/Models/Product.cs
@@ -41,6 +41,10 @@ namespace Bangazon.Models
 
         public string City {get; set;}
 
+        [Display(Name = "Local Delivery Available")]
+
+        public bool LocalDelivery { get; set; }
+
         public string ImagePath {get; set;}
 
         public bool Active { get; set; }

--- a/Bangazon/Views/Products/Create.cshtml
+++ b/Bangazon/Views/Products/Create.cshtml
@@ -35,6 +35,12 @@
                 <input asp-for="Quantity" class="form-control" />
                 <span asp-validation-for="Quantity" class="text-danger"></span>
             </div>
+            <div class="form-group form-check">
+                <label class="form-check-label">
+                    <input class="form-check-input" asp-for="LocalDelivery" /> @Html.DisplayNameFor(model => model.LocalDelivery)
+                </label>
+            </div>
+            @if()
             <div class="form-group">
                 <label asp-for="City" class="control-label"></label>
                 <input asp-for="City" class="form-control" />

--- a/Bangazon/Views/Products/Create.cshtml
+++ b/Bangazon/Views/Products/Create.cshtml
@@ -35,17 +35,17 @@
                 <input asp-for="Quantity" class="form-control" />
                 <span asp-validation-for="Quantity" class="text-danger"></span>
             </div>
-            <div class="form-group form-check">
-                <label class="form-check-label">
-                    <input class="form-check-input" asp-for="LocalDelivery" /> @Html.DisplayNameFor(model => model.LocalDelivery)
-                </label>
-            </div>
-            @if()
-            <div class="form-group">
-                <label asp-for="City" class="control-label"></label>
-                <input asp-for="City" class="form-control" />
-                <span asp-validation-for="City" class="text-danger"></span>
-            </div>
+            <div class="custom-control custom-checkbox">
+                <input type="checkbox" class="custom-control-input" asp-for="LocalDelivery" id="localDelivery" checked="">
+                <label class="custom-control-label" for="localDelivery">@Html.DisplayNameFor(model => model.LocalDelivery)</label>
+            
+                <div class="reveal-if-active form-group">
+                    <br/>
+                     <label asp-for="City" class="control-label"></label>
+                     <input asp-for="City" class="form-group"  />
+                     <span asp-validation-for="City" class="text-danger"></span>
+                </div>
+             </div>
             <div class="form-group">
                 <label asp-for="ImagePath" class="control-label"></label>
                 <input asp-for="ImagePath" class="form-control" />

--- a/Bangazon/wwwroot/lib/bootstrap/dist/css/bootstrap.css
+++ b/Bangazon/wwwroot/lib/bootstrap/dist/css/bootstrap.css
@@ -35,7 +35,20 @@
     --font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
-.linkColor{
+.reveal-if-active {
+    opacity: 0;
+    max-height: 0;
+    overflow: hidden;
+}
+
+input[type="checkbox"]:checked ~ .reveal-if-active {
+    opacity: 1;
+    max-height: 100px; 
+    overflow: visible;
+}
+
+
+.linkColor {
     color: whitesmoke !important;
 }
 


### PR DESCRIPTION
# Description

Given a user is uploading a product to sell
When the product form is displayed
Then the user will have an option to specify that local delivery is available
And the user can add the city to be used as a searchable field in the main application

Fixes #3 

## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)


# Testing Instructions
Update-Database
Add a product with local delivery and no local delivery options. Search for city to see local delivery options.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
