### PR TITLE
home page shows most recent 20 items added

### DIFF
--- a/Bangazon/Controllers/HomeController.cs
+++ b/Bangazon/Controllers/HomeController.cs
@@ -35,6 +35,7 @@ namespace Bangazon.Controllers
                 var products = await _context.Product
                     .Where(p => p.Active == true)
                     .Include(p => p.ProductType)
+                    .OrderByDescending(p=>p.DateCreated).Take(20)
                    .ToListAsync();
                 return View(products);
             }

--- a/Bangazon/Controllers/HomeController.cs
+++ b/Bangazon/Controllers/HomeController.cs
@@ -53,3 +53,4 @@ namespace Bangazon.Controllers
         }
     }
 }
+


### PR DESCRIPTION
# Description
Given a user visits the home page of Bangazon
When the page renders
Then the last 20 products that have been added to the system will be displayed as hyperlinks to their respective detail pages

Fixes #18 

## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)


# Testing Instructions

Add products to database if less than 21.  On home page, user should see the 20 most recently added products in descending date order.


# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
